### PR TITLE
Permit -g option alias for --geometry (see urxvt, mlterm, st).

### DIFF
--- a/roxterm.1.xml.in
+++ b/roxterm.1.xml.in
@@ -77,7 +77,8 @@ and docbook-xsl in your Build-Depends control field.
       <arg><option>--help-all</option></arg>
       <arg><option>--help-gtk</option></arg>
       <arg><option>-u</option> | <option>--usage</option></arg>
-      <arg><option>--geometry=<replaceable>GEOM</replaceable></option></arg>
+      <arg><option>--geometry=<replaceable>GEOM</replaceable></option>
+        | <option>-g <replaceable>GEOM</replaceable></option></arg>
       <arg><option>--appdir=<replaceable>DIR</replaceable></option></arg>
       <arg><option>--profile=<replaceable>PROFILE</replaceable></option> |
         <option>-p <replaceable>PROFILE</replaceable></option></arg>
@@ -163,7 +164,9 @@ and docbook-xsl in your Build-Depends control field.
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--geometry=<replaceable>COLUMNSxROWS</replaceable></option>
+        <term>
+            <option>-g <replaceable>COLUMNSxROWS</replaceable></option>
+            <option>--geometry=<replaceable>COLUMNSxROWS</replaceable></option>
         </term>
         <listitem>
           <para>Set size of terminal.</para>

--- a/src/globalopts.c
+++ b/src/globalopts.c
@@ -79,8 +79,8 @@ static gboolean global_options_show_usage(const gchar *option_name,
     (void) data;
     (void) value;
     (void) option_name;
-    puts("roxterm [-?|--help] [--usage] [--geometry=GEOMETRY] [--appdir=DIR]\n"
-      "    [--session=SESSION]\n"
+    puts("roxterm [-?|--help] [--usage] [--geometry=GEOMETRY|-g GEOMETRY]\n"
+      "    [--session=SESSION] [--appdir=DIR]\n"
       "    [--profile=PROFILE|-p PROFILE]\n"
       "    [--colour-scheme=SCHEME|--color-scheme=SCHEME|-c SCHEME]\n"
       "    [--shortcut-scheme=SCHEME|-s SCHEME]\n"
@@ -192,7 +192,7 @@ static GOptionEntry global_g_options[] = {
     { "directory", 'd', G_OPTION_FLAG_IN_MAIN,
         G_OPTION_ARG_CALLBACK, global_options_set_directory,
         N_("Set the terminal's working directory"), N_("DIRECTORY") },
-    { "geometry", 0, G_OPTION_FLAG_IN_MAIN,
+    { "geometry", 'g', G_OPTION_FLAG_IN_MAIN,
         G_OPTION_ARG_CALLBACK, global_options_set_string,
         N_("Set size of terminal"),
         N_("COLUMNSxROWS") },


### PR DESCRIPTION
This proposes -g as an alias for --geometry. Three of my other favorite terminals, urxvt, mlterm and st, also support this.