### PR TITLE
Tab title format '%n' and '%t'

### DIFF
--- a/src/multitab.c
+++ b/src/multitab.c
@@ -398,6 +398,8 @@ static char *make_title(const char *template, const char *title, int num, int po
             {
                 if (*s != '%')
                     *d++ = *s;
+                else if (s[1] == '\0')
+                    break;
                 else if (*++s == '%')
                     *d++ = '%';
                 else if (*s == 's')

--- a/src/roxterm-config.ui
+++ b/src/roxterm-config.ui
@@ -3133,7 +3133,7 @@
                                   <object class="GtkEntry" id="title_string">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">The title string may include '%s' which is substituted with the title set by the child command (usually the current directory for shells). No other % characters or sequences are permitted except '%%' which is displayed as a single %.</property>
+                                    <property name="tooltip_text" translatable="yes">The title string may include '%s' which is substituted with the title set by the child command (usually the current directory for shells). '%n' is substituted by the number of tabs and '%t' by the current tab number. No other % characters or sequences are permitted except '%%' which is displayed as a single %.</property>
                                     <property name="hexpand">True</property>
                                     <property name="invisible_char">●</property>
                                     <signal name="activate" handler="on_entry_activate" swapped="no"/>


### PR DESCRIPTION
I prefer not to have a menubar or tabbar in my roxterm to save on screen surface,
but I still want to quickly see if my roxterm has tabs and which tab I'm currently in.
Hence I wish to see this in the window frame titlebar.
This PR adds '%n' and '%t' to the existing '%s' title string format option.