### PR TITLE
Enable per-profile GTK styling via new classname on VteTerminal

### DIFF
--- a/docs/en/guide.html
+++ b/docs/en/guide.html
@@ -43,6 +43,7 @@
 				<li><a href="#KeyboardShortcuts">Keyboard Shortcuts</a></li>
 				<li><a href="#ConfigurationManagement">Configuration Management</a></li>
 				<li><a href="#CommandlineOptions">Command-line Options</a></li>
+				<li><a href="#GtkStyling">GTK Styling</a></li>
 				<li><a href="#AdvancedDbusUsage">Advanced D-bus Usage</a></li>
 			</ol>
 
@@ -192,6 +193,32 @@
 				--shortcut-scheme respectively in 1.7.0 (underscores changed to hyphens) but the old versions remain usable for
 				backwards compatibility.</p>
 
+
+				<h2>GTK Styling <a class="pageAnchor" name="GtkStyling">:</a></h2>
+
+				<p>Like any VTE-based terminal, you can apply custom GTK styles on ROXTerm terminals.</p>
+
+				<p>A common use-case is to add padding around the terminal content. You can do this by adding the following to your global GTK stylesheet in ~/.config/gtk-3.0/gtk.css:</p>
+
+				<p class="snippet">
+					<span>VteTerminal,</span>
+					<span>vte-terminal {</span>
+					<span>&nbsp;&nbsp;-VteTerminal-inner-border: 20px;</span>
+					<span>&nbsp;&nbsp;padding: 20px;</span>
+					<span>}</span>
+				</p>
+
+				<p>Per-profile styling is possible by targeting specific classes in the GTK stylesheet. For example, if you want to apply a different padding to a profile named "Minimal", while still keeping your default padding, you can add this style rule after the previous one:</p>
+
+				<p class="snippet">
+					<span>VteTerminal.roxterm-Minimal,</span>
+					<span>vte-terminal.roxterm-Minimal {</span>
+					<span>&nbsp;&nbsp;-VteTerminal-inner-border: 2px;</span>
+					<span>&nbsp;&nbsp;padding: 2px;</span>
+					<span>}</span>
+				</p>
+
+				<p>When a profile name contains spaces, the generated class replaces them with hyphens.</p>
 
 				<h2>Advanced D-Bus Usage <a class="pageAnchor" name="AdvancedDbusUsage">:</a></h2>
 

--- a/src/roxterm.c
+++ b/src/roxterm.c
@@ -2965,6 +2965,33 @@ static void roxterm_apply_show_add_tab_btn(ROXTermData *roxterm)
     }
 }
 
+static void roxterm_apply_css_class(ROXTermData *roxterm)
+{
+    GtkStyleContext *context = gtk_widget_get_style_context(roxterm->widget);
+    const char *profile_name = options_get_leafname(roxterm->profile);
+
+    // remove any existing roxterm profile classes
+    GList *classes = gtk_style_context_list_classes(context);
+    GList *l;
+    for (l = classes; l; l = l->next)
+    {
+        const char *class = l->data;
+        if (g_str_has_prefix(class, "roxterm-"))
+        {
+            gtk_style_context_remove_class(context, class);
+        }
+    }
+
+    /* make sure the generated class name is roxterm specific with a prefix,
+    and does not contain any whitespaces so that it's a valid CSS class name */
+    char *profile_class = g_strconcat(
+        "roxterm-",
+        g_strdelimit(g_strdup(profile_name), " ", '-'),
+        NULL
+    );
+    gtk_style_context_add_class(context, profile_class);
+}
+
 static void
 roxterm_apply_bold_is_bright(ROXTermData *roxterm, VteTerminal *vte)
 {
@@ -3118,6 +3145,8 @@ static void roxterm_apply_profile(ROXTermData *roxterm, VteTerminal *vte,
     roxterm_apply_colour_scheme_from_profile(roxterm);
 
     roxterm_apply_show_add_tab_btn(roxterm);
+
+    roxterm_apply_css_class(roxterm);
 }
 
 static gboolean


### PR DESCRIPTION
:wave: 

Following up on https://github.com/realh/roxterm/issues/259, this is my take on it after following your advice @realh :)

The idea is that every ROXTerm terminal now has a roxterm profile-specific classname applied to its GTK VteTerminal widget.

The class applied is built like this: `roxterm-{profile name with dashes instead of whitespaces}`.

This enables targeting different ROXTerm profiles in a global gtk.css file. For example, if you want to have 20px padding by default, but not for a ROXTerm profile called "Small View":

```
vte-terminal {
  padding: 20px;
}

vte-terminal.roxterm-Small-View {
  padding: 2px;
}
```

____

I'm not a C developer at all so please excuse me if the code is not that great…

I also added a section about GTK styling in the user guide if you see value in that.