### PR TITLE
Fix search Match Case checkbox behavior

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -257,7 +257,7 @@ static void search_response_cb(GtkWidget *widget,
                 gtk_toggle_button_get_active(search_data.backwards);
         guint flags =
                 (gtk_toggle_button_get_active(search_data.match_case) ?
-                        0 : ROXTERM_SEARCH_MATCH_CASE) |
+                        ROXTERM_SEARCH_MATCH_CASE : 0) |
                 (gtk_toggle_button_get_active(search_data.as_regex) ?
                         ROXTERM_SEARCH_AS_REGEX : 0) |
                 (gtk_toggle_button_get_active(search_data.entire_word) ?


### PR DESCRIPTION
The Match Case checkbox always changed its state
after running a search. This fix corrects how the
checkbox state is stored/resotred in search flags.