### PR TITLE
Update debian control version and fix lintian errors based on it

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -304,8 +304,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -329,8 +328,8 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@ roxterm (3.18.2-1) UNRELEASED; urgency=medium
   * New upstream version:
     + Merged github PR for better compatibility with CMake 4.
 
- -- Tony Houghton <h@realh.co.uk>  Fri, 04 May 2026 13:24:15 +0100
+ -- Tony Houghton <h@realh.co.uk>  Mon, 04 May 2026 13:24:15 +0100
 
 roxterm (3.18.1-1) UNRELEASED; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends:
  libpcre2-dev,
  libvte-2.91-dev (>= 0.52),
  xsltproc
-Standards-Version: 4.1.1
+Standards-Version: 4.7.0
 Homepage: https://github.com/realh/roxterm
 Vcs-Git: https://github.com/realh/roxterm.git
 Vcs-Browser: https://github.com/realh/roxterm

--- a/debian/copyright
+++ b/debian/copyright
@@ -31,8 +31,7 @@ License: GPL-2+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this package; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+ along with this package. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
  Public License can be found in /usr/share/common-licenses/GPL-2.
@@ -49,8 +48,7 @@ License: GPL-3+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this package; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+ along with this package. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
  Public License can be found in /usr/share/common-licenses/GPL-3.


### PR DESCRIPTION
"Lintian" tool reported a typo in date, and that FSF address should be written as an URL, instead of the old office. 
The updated license file can be simply taken from Debian standard file, I included the path in the git commit.
The version is just pulled to newest, I'm not sure what implications that makes!