### PR TITLE
Define hotkey file for Hungarian menus

### DIFF
--- a/Config/Shortcuts/Default_Hungarian
+++ b/Config/Shortcuts/Default_Hungarian
@@ -1,0 +1,23 @@
+[roxterm shortcuts scheme]
+Fájl/Új ablak=<Shift><Control>n
+Fájl/Új lap=<Shift><Control>t
+Fájl/Ablak bezárása=<Shift><Control>q
+Fájl/Lap bezárása=<Shift><Control>w
+Lapok/Előző lap=<Control>Page_Up
+Lapok/Következő lap=<Control>Page_Down
+Szerkesztés/Összes kijelölése=<Shift><Control>a
+Szerkesztés/Másolás=<Shift><Control>c
+Szerkesztés/Beillesztés=<Shift><Control>v
+Nézet/Menü megjelenítése=<Shift><Control>m
+Nézet/Nagyítás=<Control>plus
+Nézet/Kicsinyítés=<Control>minus
+Nézet/Normál méret=<Control>0
+Nézet/Teljes képernyő=F11
+Nézet/Keret nélkül=<Shift><Control>b
+Nézet/Görgetés fel egy sorral=<Shift>Up
+Nézet/Görgetés le egy sorral=<Shift>Down
+Súgó/Kézikönyv megjelenítése=F1
+Szerkesztés/Másolás és beillesztés=<Shift><Control>y
+Keresés/Keresés...=<Shift><Control>f
+Keresés/Következő keresése=<Shift><Control>i
+Keresés/Előző keresése=<Shift><Control>p


### PR DESCRIPTION
The file requires a patch that main menus are referred in this file in localized language, i.e. instead of
File/Új ablak
this file defines:
Fájl/Új ablak
which does not work without a fix that I submit separately.
(An alternative approach would be to use English names in the file, but that leaves local language users helpless on what to type in. A switch to such file could be possible if this page had a GUI or will have later.)

Items in this file match original English hotkey setup, just offer a working alternative set in the menu for Hungarian GUI. I don't know if that should/could be solved better than another default set. I'm not sure what would be the best to keep this, still not extend the menu with every single language... :-(